### PR TITLE
show random GIFs from giphy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A sample runner configuration looks like below:
 export SLACK_API_TOKEN="<SLACK_API_TOKEN<"
 export GITHUB_TOKEN="<GITHUB_TOKEN>"
 export GOOGLE_API_KEY="<GOOGLE_API_KEY>"
+export GIPHY_API_KEY="<GIPHY_API_KEY>"
 export STANDUP_CHANNEL="scrum"
 export GH_CHANNEL="github"
 export PWN_CHANNEL="critical"
@@ -127,6 +128,7 @@ Currently, there are following responders and these should ideally work with any
 - `ExMustang.Responders.Birthday` - send a happy birthday to the mentioned user
 - `ExMustang.Responders.InviteAll` - invite all members (of optionally given channel)
 - `ExMustang.Responders.UrbanDictionary` - presents urban dictionary word of the day
+- `ExMustang.Responders.Giphy` - renders gif using https://giphy.com
 
 For Google Maps search, you have to set `GOOGLE_API_KEY` which has access to call google places api.
 
@@ -152,6 +154,7 @@ gittip [keyword] - Get a random git tip for given keyword
 happy birthday <me|@user> - Send happy birthday message to the user mentioned
 hdeploy <app-name> - Deploys configured branch to the given app
 inviteall [src_channel] - invite all the members of source channel
+giphy [search_term] - Tries to find a GIF matching search_term (gives random gif if no search_term is provided)
 ```
 
 #### Heroku Deployment

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,7 @@ config :ex_mustang, ExMustang.Responders.Standup,
   slack_channel: System.get_env("STANDUP_CHANNEL") || "general",
   suffix: ["folks", "hackers", "peeps", "avengers"],
   msg: "Standup time",
-  enabled: false
+  enabled: true
 
 config :ex_mustang, ExMustang.Responders.Github,
   repos: ["techgaun/ex_mustang"],
@@ -18,20 +18,20 @@ config :ex_mustang, ExMustang.Responders.Github,
   created_time_threshold: 10800,
   # no old than 1 hour
   updated_time_threshold: 3600,
-  enabled: false
+  enabled: true
 
 config :ex_mustang, ExMustang.Responders.Quote,
   quote_src: "files/quotes.txt",
   schedule: "1 10 * * *",
   slack_channel: System.get_env("QUOTE_CHANNEL") || "general",
-  enabled: false
+  enabled: true
 
 config :ex_mustang, ExMustang.Responders.InviteAll,
   slack_token: System.get_env("SLACK_INVITEALL_TOKEN")
 
 config :ex_mustang, ExMustang.Responders.Pwned,
   schedule: "59 23 */1 * *",
-  enabled: false,
+  enabled: true,
   accounts: [
     "abc@example.com",
     "def@example.com"
@@ -40,7 +40,7 @@ config :ex_mustang, ExMustang.Responders.Pwned,
 
 config :ex_mustang, ExMustang.Responders.Uptime,
   schedule: "*/5 * * * *",
-  enabled: false,
+  enabled: true,
   endpoints: [
     [
       uri: "https://api.brighterlink.io/status",

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,7 @@ config :ex_mustang, ExMustang.Responders.Standup,
   slack_channel: System.get_env("STANDUP_CHANNEL") || "general",
   suffix: ["folks", "hackers", "peeps", "avengers"],
   msg: "Standup time",
-  enabled: true
+  enabled: false
 
 config :ex_mustang, ExMustang.Responders.Github,
   repos: ["techgaun/ex_mustang"],
@@ -18,20 +18,20 @@ config :ex_mustang, ExMustang.Responders.Github,
   created_time_threshold: 10800,
   # no old than 1 hour
   updated_time_threshold: 3600,
-  enabled: true
+  enabled: false
 
 config :ex_mustang, ExMustang.Responders.Quote,
   quote_src: "files/quotes.txt",
   schedule: "1 10 * * *",
   slack_channel: System.get_env("QUOTE_CHANNEL") || "general",
-  enabled: true
+  enabled: false
 
 config :ex_mustang, ExMustang.Responders.InviteAll,
   slack_token: System.get_env("SLACK_INVITEALL_TOKEN")
 
 config :ex_mustang, ExMustang.Responders.Pwned,
   schedule: "59 23 */1 * *",
-  enabled: true,
+  enabled: false,
   accounts: [
     "abc@example.com",
     "def@example.com"
@@ -40,7 +40,7 @@ config :ex_mustang, ExMustang.Responders.Pwned,
 
 config :ex_mustang, ExMustang.Responders.Uptime,
   schedule: "*/5 * * * *",
-  enabled: true,
+  enabled: false,
   endpoints: [
     [
       uri: "https://api.brighterlink.io/status",
@@ -87,7 +87,8 @@ config :ex_mustang, ExMustang.Robot,
     {ExMustang.Responders.HerokuDeploy, []},
     {ExMustang.Responders.InviteAll, []},
     {ExMustang.Responders.UrbanDictionary, []},
-    {ExMustang.Responders.ChuckMe, []}
+    {ExMustang.Responders.ChuckMe, []},
+    {ExMustang.Responders.Giphy, []}
   ]
 
 config :quantum, timezone: System.get_env("SYSTEM_TIME") || "America/Chicago"
@@ -95,6 +96,8 @@ config :quantum, timezone: System.get_env("SYSTEM_TIME") || "America/Chicago"
 config :ex_google,
   api_key: System.get_env("GOOGLE_API_KEY"),
   output: "json"
+
+config :ex_mustang, ExMustang.Responders.Giphy, api_key: System.get_env("GIPHY_API_KEY")
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/ex_mustang/responders/giphy.ex
+++ b/lib/ex_mustang/responders/giphy.ex
@@ -60,7 +60,7 @@ defmodule ExMustang.Responders.Giphy do
     end
   end
 
-  defp extract_gif(%{"data" => %{"image_url" => image_url}}) do
+  defp extract_gif(%{"data" => %{"images" => %{"downsized" => %{"url" => image_url}}}}) do
     image_url
   end
 

--- a/lib/ex_mustang/responders/giphy.ex
+++ b/lib/ex_mustang/responders/giphy.ex
@@ -10,8 +10,7 @@ defmodule ExMustang.Responders.Giphy do
   @api_key Application.get_env(:ex_mustang, ExMustang.Responders.Giphy)[:api_key]
 
   @usage """
-  giphy - Gets a random gif from giphy
-  giphy <string> - Tries to find a gif matching <string>
+  giphy [search_term] - Tries to find a GIF matching search_term (gives random gif if no search_term is provided)
   """
 
   hear ~r/^giphy\s?(?<tag>.*)$/i, msg do

--- a/lib/ex_mustang/responders/giphy.ex
+++ b/lib/ex_mustang/responders/giphy.ex
@@ -1,0 +1,70 @@
+defmodule ExMustang.Responders.Giphy do
+  @moduledoc """
+  Grabs a random gif from Giphy
+  """
+  use Hedwig.Responder
+  import ExMustang.Utils, only: [useragent: 0]
+
+  @random_gif_url "https://api.giphy.com/v1/gifs/random"
+  @translate_gif_url "https://api.giphy.com/v1/gifs/translate"
+  @api_key Application.get_env(:ex_mustang, ExMustang.Responders.Giphy)[:api_key]
+
+  @usage """
+  giphy - Gets a random gif from giphy
+  giphy <string> - Tries to find a gif matching <string>
+  """
+
+  hear ~r/^giphy\s?(?<tag>.*)$/i, msg do
+    response =
+      msg.matches["tag"]
+      |> get_gif()
+
+    reply(msg, response)
+  end
+
+  @doc """
+  Get random GIF to show
+  """
+  def get_gif("") do
+    case @random_gif_url
+         |> URI.parse()
+         |> Map.put(:query, URI.encode_query(%{api_key: @api_key, rating: "g"}))
+         |> URI.to_string()
+         |> HTTPoison.get([useragent()]) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        body
+        |> Poison.decode!()
+        |> extract_gif()
+
+      _ ->
+        "Giphy not available right now"
+    end
+  end
+
+  @doc """
+  Get translated GIF to show
+  """
+  def get_gif(string) do
+    case @translate_gif_url
+         |> URI.parse()
+         |> Map.put(:query, URI.encode_query(%{api_key: @api_key, s: string}))
+         |> URI.to_string()
+         |> HTTPoison.get([useragent()]) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        body
+        |> Poison.decode!()
+        |> extract_gif()
+
+      _ ->
+        "Giphy not available right now"
+    end
+  end
+
+  defp extract_gif(%{"data" => %{"image_url" => image_url}}) do
+    image_url
+  end
+
+  defp extract_gif(_) do
+    "Unable to parse the gif. Maybe it just wasn't a good match."
+  end
+end


### PR DESCRIPTION
Closes issue #33 

You can create an API key on `https://developers.giphy.com/`
- `giphy` command will return random GIF with `G` rating so that it is SFW
- `giphy <search>` command will return random GIF matching the `<search>` term
